### PR TITLE
feat: change polyfill to use yaffle

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,9 +1,4 @@
 /* eslint-disable no-var */
-var evs = require('@rexxars/eventsource-polyfill')
+var evs = require("event-source-polyfill");
 
-module.exports =
-  typeof window === 'undefined' || !window.EventSource
-    ? // Use polyfill in non-browser/legacy environments
-      evs.EventSource
-    : // Use native EventSource when we can
-      window.EventSource
+module.exports = evs.EventSourcePolyfill;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/eventsource",
-  "version": "2.23.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/eventsource",
-      "version": "2.23.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "event-source-polyfill": "^1.0.25",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "@sanity/eventsource",
+  "version": "2.23.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@sanity/eventsource",
+      "version": "2.23.0",
+      "license": "MIT",
+      "dependencies": {
+        "event-source-polyfill": "^1.0.25",
+        "eventsource": "^1.0.6"
+      }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.25.tgz",
+      "integrity": "sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg=="
+    },
+    "node_modules/eventsource": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "dependencies": {
+        "url-parse": "^1.4.3"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.6.tgz",
+      "integrity": "sha512-xj3QdUJ1DttD1LeSfvJlU1eiF1RvBSBfUu8GplFGdUzSO28y5yUtEl7wb//PI4Af6qh0o/K8545vUmucRrfWsw==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "event-source-polyfill": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.25.tgz",
+      "integrity": "sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg=="
+    },
+    "eventsource": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
+      "requires": {
+        "original": "^1.0.0"
+      }
+    },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "requires": {
+        "url-parse": "^1.4.3"
+      }
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "url-parse": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.6.tgz",
+      "integrity": "sha512-xj3QdUJ1DttD1LeSfvJlU1eiF1RvBSBfUu8GplFGdUzSO28y5yUtEl7wb//PI4Af6qh0o/K8545vUmucRrfWsw==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/eventsource.git",
+    "url": "git+https://github.com/sanity-io/eventsource.git"
   },
   "keywords": [
     "sanity",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@sanity/eventsource",
-  "version": "2.23.0",
+  "version": "3.0.0",
   "description": "EventSource polyfill for browser and node.js",
   "main": "./node.js",
   "browser": "./browser.js",
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git",
-    "directory": "packages/@sanity/eventsource"
+    "url": "git+https://github.com/sanity-io/eventsource.git",
   },
   "keywords": [
     "sanity",
@@ -26,7 +25,7 @@
   },
   "homepage": "https://www.sanity.io/",
   "dependencies": {
-    "@rexxars/eventsource-polyfill": "^1.0.0",
+    "event-source-polyfill": "^1.0.25",
     "eventsource": "^1.0.6"
   }
 }


### PR DESCRIPTION
In combination with this [PR](https://github.com/sanity-io/sanity/pull/3152) and an adding token support branch in the mono repo

- this PR updates the polyfill used (from `@rexxars/eventsource-polyfill` to `event-source-polyfill` (yaffle)
- and updates the behavior to always use the polyfil by default