### PR TITLE
React-native export

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
         "types": "./browser.d.ts",
         "default": "./browser.js"
       },
+      "react-native": {
+        "types": "./browser.d.ts",
+        "default": "./browser.js"
+      },
       "deno": "./browser.js",
       "edge-light": "./browser.js",
       "worker": "./browser.js",


### PR DESCRIPTION
Building a react-native expo app with `@sanity/client` while using the `unstable_enablePackageExports` metro config setting caused the app to use the incorrect polyfill of eventsource. Adding this export points react-native to the correct polyfill. With help from @joriregter ✌🏽 