### PR TITLE
fix: stop publishing CHANGELOG.md to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     }
   },
   "files": [
-    "CHANGELOG.md",
     "browser.js",
     "browser.d.ts",
     "node.js",


### PR DESCRIPTION
This change reduces the tarball and space used in `node_modules`, while also allowing me to test that the release-please pipeline still works after we changed the bot that runs the release, and now have GHE org-level enforced branch rules. It's been 2 years since the last release after all (5.0.2 published in April 2024)