### PR TITLE
fix: add ESM browser entry for bundlers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Sanity.io
+Copyright (c) 2026 Sanity.io
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/browser.d.mts
+++ b/browser.d.mts
@@ -1,0 +1,2 @@
+declare const EventSourcePolyfill: typeof import('event-source-polyfill').EventSourcePolyfill
+export default EventSourcePolyfill

--- a/browser.mjs
+++ b/browser.mjs
@@ -1,0 +1,2 @@
+import EventSourcePolyfill from './browser.js'
+export default EventSourcePolyfill

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     ".": {
       "types": "./node.d.ts",
       "browser": {
+        "import": {
+          "types": "./browser.d.mts",
+          "default": "./browser.mjs"
+        },
         "types": "./browser.d.ts",
         "default": "./browser.js"
       },
@@ -65,7 +69,9 @@
   },
   "files": [
     "browser.js",
+    "browser.mjs",
     "browser.d.ts",
+    "browser.d.mts",
     "node.js",
     "node.d.ts"
   ],


### PR DESCRIPTION
## Summary

Sanity Studio (and anything on `@sanity/client`) crashes under Vite 8's experimental bundled dev mode (`sanity dev` with `unstable_bundledDev: true`) with `TypeError: EventSource2 is not a constructor` the moment the first authenticated EventSource listener is created.

Root cause is an upstream Rolldown bug in bundled dev mode's lazy compilation of dynamic imports whose **entry module is CommonJS**: the fetched proxy template (`crates/rolldown_plugin_lazy_compilation/src/proxy-module-template-fetched.js`) awaits the CJS→ESM interop expression but returns the raw registered `module.exports`, and the dev finalizer (`crates/rolldown/src/hmr/hmr_ast_finalizer.rs`, the `__toDynamicImportESM` call with a `// FIXME: consider about CommonJS interop` above it) invokes the curried runtime helper with the wrong arity, so interop never applies. Confirmed in vite 8.1.4 / rolldown 1.1.5, still present on rolldown `main` as of 2026-07-15. This package's browser entry is CJS, and `@sanity/client` does `import('@sanity/eventsource').then(({default: EventSource}) => ...)`, so the namespace is the bare `EventSourcePolyfill` function, `default` is `undefined`, and `new` throws.

Since only a **dynamically imported CJS entry** triggers the bug (static CJS imports go through Rolldown's working `__toESM` interop), the fix is a two-line additive ESM wrapper:

- `browser.mjs` — default-re-exports the existing `./browser.js` (both formats share one module instance; no dual-package hazard)
- `browser.d.mts` — matching ESM declaration (the existing `browser.d.ts` is CJS-style `export =`)
- `package.json` — routes only the root export's `browser` → `import`/`import()` resolution to the wrapper; `require` and every legacy path keep resolving `./browser.js` byte-for-byte as today

Top-level `browser`/`main`/`types`/`typesVersions`, the `react-native`/`deno`/`edge-light`/`worker`/`node`/`default` conditions, and the `./browser` + `./node` subpaths are untouched. The wrapper stays harmless after Rolldown fixes the upstream bug.

## Verification (all against the packed tarball, not a symlink)

**Bug repro** — vite@8.1.4, `experimental: { bundledDev: true }`, entry `const {default: ES} = await import('@sanity/eventsource')`, loaded in a real browser:
- 5.0.3 (published): module namespace is the bare function, `default` is `undefined` → broken
- patched tarball: `default` is the `EventSourcePolyfill` constructor, `new ES(url)` constructs, listener works

**Resolution regression matrix** — asserted byte-identical to published 5.0.3 except the intended browser-import path:
- Node 16.20.2 / 18.20.8 / 24.18.0: `require` + `import()` of `.`, `./browser`, `./node` → same files, same values (Node never matches `browser`); `node --conditions=browser` additionally proves the nested condition resolves `browser.mjs` for import and `browser.js` for require
- Bundlers (browser target, static + dynamic import, executed in a real browser): vite 5 dev + build, vite 8 dev + build + bundledDev, webpack 5, esbuild (`--splitting`), `bun build` — default export is the constructor everywhere
- Runtimes: bun 1.3.5 and deno 2.9.2 resolve the bare specifier exactly as before (bun → `node.js`, deno → `browser.js` via the untouched `deno` condition)

**Types**
- `attw --pack`: "No problems found" before and after (node10 / node16 CJS / node16 ESM / bundler all green)
- `publint`: same two pre-existing suggestions; one new informational warning about the *pre-existing* root `types` condition being CJS-interpreted under `import` (applies to `node.d.ts`, predates this change, out of scope for a patch)
- Consumer `tsc --noEmit` (TS 5.9): `moduleResolution: bundler` with and without `customConditions: ["browser"]`, and `node16` ESM + CJS — identical behavior to published, all pass
- `sort-package-json` (prettier-plugin-packagejson v3) idempotency: does not reorder the nested conditions

**Package contents** — tarball diff vs published 5.0.3: only `browser.mjs`, `browser.d.mts`, the two `files` entries, the one exports-map addition (plus the LICENSE year bump from the `chore` commit). Repo `npm test` and `prepublishOnly` (tsc) pass with a clean tree.

**Consumers** — grepped published dists: `@sanity/client` v6/v7 and `sanity` v5/v6 use `defer(() => import('@sanity/eventsource'))` (browser), `@sanity/client` v5 uses `await import('@sanity/eventsource')`; none use the `./browser` or `./node` subpaths, which are unchanged anyway.

Releases as a patch via release-please (`fix:` commit).

Made with [Cursor](https://cursor.com)